### PR TITLE
Indicate progress of time on exhibitor timeline

### DIFF
--- a/src/app/exhibitor/_components/ExhibitorTimeline.tsx
+++ b/src/app/exhibitor/_components/ExhibitorTimeline.tsx
@@ -1,29 +1,21 @@
 import { P } from "@/app/_components/Paragraph"
-import { fetchDates } from "@/components/shared/hooks/api/useDates"
-import { Button } from "@/components/ui/button"
 import { TimelineItem } from "@/app/exhibitor/_components/TimelineItem"
+import { fetchDates } from "@/components/shared/hooks/api/useDates"
 import { Accordion } from "@/components/ui/accordion"
+import { Button } from "@/components/ui/button"
+import { formatDate } from "@/lib/utils"
 
-import { DateTime } from "luxon"
 import Link from "next/link"
-
-function formatDate(date: string) {
-	return DateTime.fromISO(date).toFormat(
-		`d MMMM ${DateTime.fromISO(date).year !== DateTime.now().year ? " YYYY" : ""}`
-	)
-}
 
 export async function ExhibitorTimeline() {
 	const dates = await fetchDates()
 
 	//ASSUMPTION: the start date will be first for fair dates
 	return (
-		<Accordion
-			type="single"
-			collapsible={true}
-			className="relative mt-10 border-s border-melon-700">
+		<Accordion type="single" collapsible={true} className="relative mt-10">
 			<TimelineItem
-				dateString={`Before ${formatDate(dates.ir.start)}`}
+				dateStringISO={dates.ir.start}
+				dateStringHuman={`Before ${formatDate(dates.ir.start)}`}
 				title="Armada is setting up">
 				<P className="mt-3 text-stone-400">
 					Before the Initial Registration can open, we need to make
@@ -38,7 +30,7 @@ export async function ExhibitorTimeline() {
 			</TimelineItem>
 
 			<TimelineItem
-				dateString={formatDate(dates.ir.start)}
+				dateStringISO={dates.ir.start}
 				title="Initial Registration starts">
 				<P className="mt-3 text-stone-400">
 					Initial Registration is where you apply to be an exhibitor. When you
@@ -78,11 +70,11 @@ export async function ExhibitorTimeline() {
 			</TimelineItem>
 
 			<TimelineItem
-				dateString={formatDate(dates.ir.end)}
+				dateStringISO={dates.ir.end}
 				title="Initial Registration ends"></TimelineItem>
 
 			<TimelineItem
-				dateString={formatDate(dates.ir.acceptance)}
+				dateStringISO={dates.ir.acceptance}
 				title="Acceptance date">
 				<P className="text-stone-400">
 					We will get back to everyone who made an Initial Registration by{" "}
@@ -104,7 +96,7 @@ export async function ExhibitorTimeline() {
 			</TimelineItem>
 
 			<TimelineItem
-				dateString={formatDate(dates.fr.start)}
+				dateStringISO={dates.fr.start}
 				title="Final Registration starts">
 				<P className="mt-3 text-stone-400">
 					During the Final Registration you choose your package, if you want to
@@ -134,11 +126,11 @@ export async function ExhibitorTimeline() {
 			</TimelineItem>
 
 			<TimelineItem
-				dateString={formatDate(dates.fr.end)}
+				dateStringISO={dates.fr.end}
 				title="Final Registration ends"></TimelineItem>
 
 			<TimelineItem
-				dateString={formatDate(dates.fr.end)}
+				dateStringISO={dates.fr.end}
 				title="Fair preparations start">
 				<P className="mt-3 text-stone-400">
 					Once Final Registration is complete, there are a few things that need
@@ -163,7 +155,7 @@ export async function ExhibitorTimeline() {
 			</TimelineItem>
 
 			<TimelineItem
-				dateString={formatDate(dates.events.start)}
+				dateStringISO={dates.events.start}
 				title="Event period starts">
 				<P className="mt-3 text-stone-400">
 					Before the fair we have three weeks filled with events to build up the
@@ -177,11 +169,11 @@ export async function ExhibitorTimeline() {
 			</TimelineItem>
 
 			<TimelineItem
-				dateString={formatDate(dates.events.end)}
+				dateStringISO={dates.events.end}
 				title="Event period ends"></TimelineItem>
 
 			<TimelineItem
-				dateString={formatDate(dates.fair.days[0])}
+				dateStringISO={dates.fair.days[0]}
 				title="Armada fair starts">
 				<P className="mt-3 text-stone-400">
 					The days we all have waited for! For days Armada have worked together
@@ -204,7 +196,7 @@ export async function ExhibitorTimeline() {
 			</TimelineItem>
 
 			<TimelineItem
-				dateString={formatDate(dates.fair.days[0])}
+				dateStringISO={dates.fair.days[0]}
 				title="The Grand Banquet">
 				<P className="mt-3 text-stone-400">
 					On the eve of the first fair day, Armada organizes a Grand Banquet, a
@@ -219,7 +211,7 @@ export async function ExhibitorTimeline() {
 			</TimelineItem>
 
 			<TimelineItem
-				dateString={formatDate(dates.fair.days[1])}
+				dateStringISO={dates.fair.days[1]}
 				title="Armada fair ends"></TimelineItem>
 		</Accordion>
 	)

--- a/src/app/exhibitor/_components/TimelineItem.tsx
+++ b/src/app/exhibitor/_components/TimelineItem.tsx
@@ -1,41 +1,53 @@
 import { P } from "@/app/_components/Paragraph"
-import { cn } from "@/lib/utils"
 import {
-	AccordionItem,
 	AccordionContent,
+	AccordionItem,
 	AccordionTrigger
 } from "@/components/ui/accordion"
+import { cn } from "@/lib/utils"
+import { formatDate } from "@/lib/utils"
 
 export function TimelineItem({
 	children,
 	title,
-	dateString
+	dateStringISO,
+	dateStringHuman = formatDate(dateStringISO)
 }: {
 	children?: React.ReactNode
 	title: string
-	dateString: string
+	dateStringISO: string
+	dateStringHuman?: string
 }) {
 	const expandable = children != null
+	const isPastDate = new Date(dateStringISO) <= new Date()
+
 	return (
 		<AccordionItem
 			value={title}
 			disabled={!expandable}
-			className="border-none">
-			<div className="absolute -start-1.5 mt-3.5 h-3 w-3 rounded-full border border-white bg-melon-700"></div>
+			className={cn(
+				"border-b-0 border-l-2 border-slate-600 pb-7 transition-[padding] duration-200 data-[state=open]:pb-3",
+				{ "border-melon-700": isPastDate }
+			)}>
+			<div
+				className={cn(
+					"absolute -start-1.5  size-3.5 rounded-full border border-melon-700/50 bg-slate-600",
+					{ "bg-melon-700" : isPastDate }
+				)}></div>
 			<AccordionTrigger
 				disabled={!expandable}
 				className={cn(
-					"mb-2 ml-4 w-full rounded px-2 pb-4 pt-0 text-left font-normal hover:no-underline",
-					{ "transition hover:bg-slate-700": expandable }
+					"ml-4 w-full rounded px-2 pb-1.5 text-left font-normal hover:no-underline",
+					{ "transition hover:text-melon-700": expandable }
 				)}>
 				<div>
-					<P className="text-stone-400">{dateString}</P>
+					<P className="-mt-5 text-stone-400">{dateStringHuman}</P>
 					<div className="flex w-full justify-between ">
 						<h3 className="text-2xl md:text-3xl">{title}</h3>
 					</div>
 				</div>
 			</AccordionTrigger>
-			<AccordionContent className="-mt-2 ml-1 px-5 text-base">
+			<AccordionContent className="ml-1 px-5 text-base">
 				{children}
 			</AccordionContent>
 		</AccordionItem>

--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -1,6 +1,26 @@
-import { type ClassValue, clsx } from "clsx"
+import { clsx, type ClassValue } from "clsx"
+import { DateTime } from "luxon"
 import { twMerge } from "tailwind-merge"
 
 export function cn(...inputs: ClassValue[]) {
 	return twMerge(clsx(inputs))
+}
+
+export function getDateFormatString(date: DateTime) {
+	return `d MMMM ${date.year !== DateTime.now().year ? " YYYY" : ""}`
+}
+
+export function formatDate(isoString: string) {
+	const date = DateTime.fromISO(isoString)
+	return date.toFormat(getDateFormatString(date))
+}
+
+export function formatTimestampAsDate(epochSeconds: number) {
+	const date = DateTime.fromMillis(epochSeconds * 1000)
+	return date.toFormat(getDateFormatString(date))
+}
+
+export function formatTimestampAsTime(epochSeconds: number) {
+	const date = DateTime.fromMillis(epochSeconds * 1000)
+	return date.toFormat("HH:mm")
 }


### PR DESCRIPTION
On exhibitor/timeline, entries with dates in the past are now styled differently than those with future dates. Resolves #53

![image](https://github.com/armada-ths/armada.nu/assets/67268663/6c088803-ced5-44ac-9b52-f7d9b6bd9b99)
