### PR TITLE
Fix visual bugs in exhibitor list

### DIFF
--- a/src/app/student/exhibitors/_components/ExhibitorCard.tsx
+++ b/src/app/student/exhibitors/_components/ExhibitorCard.tsx
@@ -42,11 +42,11 @@ export function ExhibitorCard({ exhibitor }: { exhibitor: Exhibitor }) {
 
 			<Link href={`/student/exhibitors?id=${exhibitor.id}`} scroll={false}>
 				<div className="to-liqorice-950 group relative flex h-full flex-col rounded-lg border-2 border-solid border-emerald-900 bg-gradient-to-b from-emerald-900 via-emerald-950 filter transition hover:scale-[1.05] hover:brightness-95">
-					<h3 className="my-2 text-center font-bebas-neue text-2xl xs:text-xl text-emerald-100 antialiased transition group-hover:text-melon-700">
+					<h3 className="my-2 text-center font-bebas-neue text-2xl text-emerald-100 antialiased transition group-hover:text-melon-700 xs:text-xl">
 						{exhibitor.name}
 					</h3>
 					{(exhibitor.logo_squared || exhibitor.logo_freesize) && (
-						<div className="relative mx-4 mt-2 flex flex-initial h-[70px] justify-center">
+						<div className="relative mt-2 flex h-[70px] w-full flex-initial justify-center px-4">
 							<Image
 								className="h-full w-full object-contain"
 								src={exhibitor.logo_squared ?? exhibitor.logo_freesize ?? ""}
@@ -59,7 +59,7 @@ export function ExhibitorCard({ exhibitor }: { exhibitor: Exhibitor }) {
 					<BadgeCollection
 						items={exhibitor.industries}
 						maxDisplayed={maxDisplayedBadges}
-						className="mt-auto p-2.5 pt-0 justify-center flex-nowrap overflow-hidden"
+						className="mt-auto flex-nowrap justify-center overflow-hidden p-2.5 pt-0"
 						badgeClassName="text-[0.65em] flex-initial truncate inline-block"
 					/>
 				</div>

--- a/src/app/student/exhibitors/_components/ExhibitorListFilteringHeader.tsx
+++ b/src/app/student/exhibitors/_components/ExhibitorListFilteringHeader.tsx
@@ -93,6 +93,7 @@ export default function ExhibitorListFilteringHeader({
 	return (
 		<div className="flex flex-wrap gap-3">
 			<Input
+				searchIcon={true}
 				ref={inputRef}
 				type="text"
 				placeholder="Search all"

--- a/src/app/student/exhibitors/_components/MultiSelect.tsx
+++ b/src/app/student/exhibitors/_components/MultiSelect.tsx
@@ -71,7 +71,7 @@ export default function MultiSelect({
 							<BadgeCollection
 								items={selected}
 								maxDisplayed={maxDisplayed}
-								className="overflow-auto"
+								className="overflow-auto flex-nowrap"
 							/>
 							<Button
 								title="Clear"
@@ -99,6 +99,7 @@ export default function MultiSelect({
 				}}>
 				<div className="w-[--radix-popover-trigger-width] rounded-md border border-emerald-800 bg-stone-950 p-0 text-sm text-stone-300 shadow-lg xs:w-max">
 					<Input
+						searchIcon={true}
 						ref={inputRef}
 						placeholder={label}
 						className="mb-1 rounded-none rounded-t-md border-0 border-b dark:border-emerald-800"

--- a/src/components/ui/drawer.tsx
+++ b/src/components/ui/drawer.tsx
@@ -11,6 +11,7 @@ const Drawer = ({
 }: React.ComponentProps<typeof DrawerPrimitive.Root>) => (
 	<DrawerPrimitive.Root
 		shouldScaleBackground={shouldScaleBackground}
+		preventScrollRestoration={false}
 		{...props}
 	/>
 )

--- a/src/components/ui/input.tsx
+++ b/src/components/ui/input.tsx
@@ -9,7 +9,7 @@ export interface InputProps
 }
 
 const Input = React.forwardRef<HTMLInputElement, InputProps>(
-	({ className, type, searchIcon = true, ...props }, ref) => {
+	({ className, type, searchIcon = false, ...props }, ref) => {
 		return (
 			<div 
 			  tabIndex={0}


### PR DESCRIPTION
Fixes bug #68 with page scrolling to the top after closing the drawer shown when clicking on an exhibitor card. Also fixes another bug where the badges in the filter dropdown trigger would sometimes wrap and overflow their container. 

[Screencast from 2024-05-27 18-24-54.webm](https://github.com/armada-ths/armada.nu/assets/67268663/dbe64b9c-c1f1-4897-aef0-4e8ab217857d)
