### PR TITLE
remove event tag in about section

### DIFF
--- a/src/components/shared/NavigationMenu.tsx
+++ b/src/components/shared/NavigationMenu.tsx
@@ -86,12 +86,6 @@ const aboutLinks: NavigationLink[] = [
     enabled: true
   },
   {
-    title: "Events",
-    href: "/student/events",
-    description: "See the events leading up to the fair",
-    enabled: feature("EVENT_PAGE")
-  },
-  {
     title: "Team",
     href: "/about/team",
     description: `Get to know the team working on Armada ${DateTime.now().year}`,


### PR DESCRIPTION
Now we only have "About Armada" and "team" buttons in the "about us" section.
![image](https://github.com/user-attachments/assets/9bf04379-e970-4fea-9bd0-d9189cad2b74)
