### PR TITLE
Fix lat/lon param zoom in, booth fix and label fix

### DIFF
--- a/src/app/student/map/_components/MapComponent.tsx
+++ b/src/app/student/map/_components/MapComponent.tsx
@@ -6,6 +6,7 @@ import { Location, LocationId } from "@/app/student/map/lib/locations"
 import { useFeatureState } from "@/components/shared/hooks/useFeatureState"
 import { useGeoJsonPlanData } from "@/components/shared/hooks/useGeoJsonPlanData"
 import "maplibre-gl/dist/maplibre-gl.css"
+import { useSearchParams } from "next/navigation"
 import { useEffect, useMemo, useRef, useState } from "react"
 import {
   Layer,
@@ -47,6 +48,8 @@ export function MapComponent({
   initialView: { longitude: number; latitude: number; zoom: number }
   filteredBoothIds: BoothID[]
 }) {
+  const searchParams = useSearchParams()
+
   const mapRef = useRef<MapRef>(null)
 
   const [mapZoom, setMapZoom] = useState(initialView.zoom)
@@ -56,15 +59,21 @@ export function MapComponent({
   const [preLocationId, setPreLocationId] = useState<LocationId>(location.id)
   // Fly to location center on change
   useEffect(() => {
+    const hasSearchParams = searchParams.has("lat") || searchParams.has("lng")
     const { longitude, latitude, zoom } = location.center
     const timeout = setTimeout(() => {
-      mapRef.current?.flyTo({
-        center: [longitude, latitude],
-        zoom
-      })
+      if (!hasSearchParams) {
+        mapRef.current?.flyTo({
+          center: [longitude, latitude],
+          zoom
+        })
+      }
+      // Remove the search params
+      const { pathname } = window.location
+      window.history.replaceState(null, "", pathname)
     }, 300)
-    return () => clearTimeout(timeout)
     setMarkerScale(0.6)
+    return () => clearTimeout(timeout)
   }, [location])
 
   useEffect(() => {

--- a/src/app/student/map/data/booths.json
+++ b/src/app/student/map/data/booths.json
@@ -70,7 +70,7 @@
       "properties": {
         "id": 5,
         "location": "nymble/2",
-        "exhibitorId": 1536
+        "exhibitorId": 1543
       },
       "geometry": {
         "coordinates": [

--- a/src/app/student/map/lib/locations.ts
+++ b/src/app/student/map/lib/locations.ts
@@ -21,12 +21,12 @@ const libraryCenter = {
 export const locations: Location[] = [
   {
     id: "nymble/2",
-    label: "Nymble-floor2",
+    label: "Nymble Floor2",
     center: nymbleCenter
   },
   {
     id: "nymble/3",
-    label: "Nymble-floor3",
+    label: "Nymble Floor3",
     center: nymbleCenter
   },
   {


### PR DESCRIPTION
Adding a missing booth.
![image](https://github.com/user-attachments/assets/edb2856f-8f8c-4b02-8c0c-03c8d4fe08b0)

Changing the floor label
![image](https://github.com/user-attachments/assets/7de4493a-e8f8-4a60-a52f-d8bde9457d52)

Fix url param coordinates not working. Map autoly zooms to location center (For QR code purpose, most obviously in mobile)
Test with(Gröten): http://localhost:8000/student/map?floor=nymble/2&lat=59.3475634854905&lng=18.0704480538623
